### PR TITLE
Use logstash 2.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:15.10
 MAINTAINER Lucas Mundim "lucas.mundim@gmail.com"
 
 # Version
-ENV LOGSTASH_VERSION 1.5.5
+ENV LOGSTASH_VERSION 2.3.1
 
 ENV PATH="/opt/logstash/bin:$PATH"
 ENV DEBIAN_FRONTEND noninteractive

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 #### Configtest
 
-`docker run --rm -it lucasmundim/logstash --configtest`
+`docker run --rm -it robsonsnjr/logstash --configtest`
 
 #### Use your own config
 
-`docker run --rm -it -v $(pwd)/logstash.conf:/logstash.conf lucasmundim/logstash`
+`docker run --rm -it -v $(pwd)/logstash.conf:/logstash.conf robsonsnjr/logstash`
 
 ## Build it locally
 


### PR DESCRIPTION
Use logstash 2.3.1 instead of 1.5.5.
Unfortunately, --auto-reload feature is not available for stdin plugin yet. So, --auto-reload (or -r) flag is not used in default config file.
